### PR TITLE
Update constants.ts

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -24,6 +24,7 @@ export const GLOBAL_IGNORE_PATTERNS = ['**/node_modules/**', '.yarn'];
 export const IGNORED_GLOBAL_BINARIES = new Set([
   'bash',
   'bun',
+  'bundle',
   'bunx',
   'cat',
   'cd',
@@ -35,12 +36,15 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'dirname',
   'docker',
   'echo',
+  'env',
   'exec',
   'exit',
   'find',
+  'gem',
   'git',
   'grep',
   'gzip',
+  'ln',
   'ls',
   'mkdir',
   'mv',
@@ -58,6 +62,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'true',
   'yarn',
   'xargs',
+  'xcodebuild',
 ]);
 
 export const IGNORED_DEPENDENCIES = new Set(['knip', 'typescript']);


### PR DESCRIPTION
After running `knip`, several common linux tools were incorrectly listed as "Unlisted binaries":

`bundle`: ruby package manager
https://www.npmjs.com/package/bundle
(Last publish: 6 years ago)

`env`: linux command for getting env vars
https://www.npmjs.com/package/env
(Last publish: 12 years ago)

`gem`: ruby tool
https://www.npmjs.com/package/gem
(Last publish: 7 years ago)

`ln`: common command for generating symlinks
https://www.npmjs.com/package/ln
(Last publish: 8 years ago)

`xcodebuild`: Apple dev tool for building macOS/iOS software
https://www.npmjs.com/package/xcodebuild
(Last publish: 10 years ago)